### PR TITLE
Reorganize reporting and enable error reporting

### DIFF
--- a/LibreNMS/Poller.php
+++ b/LibreNMS/Poller.php
@@ -190,6 +190,7 @@ class Poller
                     // isolate module exceptions so they don't disrupt the polling process
                     $this->logger->error("%rError polling $module module for {$this->device->hostname}.%n $e", ['color' => true]);
                     \Log::event("Error polling $module module. Check log file for more details.", $this->device, 'poller', Alert::ERROR);
+                    report($e);
                 }
 
                 app(MeasurementManager::class)->printChangedStats();

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -63,12 +63,6 @@ class Handler extends ExceptionHandler
         return parent::render($request, $exception);
     }
 
-    public function report(Throwable $e)
-    {
-        parent::report($e);
-        \Flare::report($e);
-    }
-
     protected function convertExceptionToArray(Throwable $e)
     {
         // override the non-debug error output to clue in user on how to debug

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -63,6 +63,12 @@ class Handler extends ExceptionHandler
         return parent::render($request, $exception);
     }
 
+    public function report(Throwable $e)
+    {
+        parent::report($e);
+        \Flare::report($e);
+    }
+
     protected function convertExceptionToArray(Throwable $e)
     {
         // override the non-debug error output to clue in user on how to debug

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,19 +3,14 @@
 namespace App\Providers;
 
 use App\Models\Sensor;
-use Config;
-use Facade\FlareClient\Report;
-use Facade\Ignition\Facades\Flare;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use LibreNMS\Cache\PermissionsCache;
-use LibreNMS\Util\Git;
+use LibreNMS\Config;
 use LibreNMS\Util\IP;
 use LibreNMS\Util\Validate;
-use LibreNMS\Util\Version;
 use Validator;
 
 class AppServiceProvider extends ServiceProvider
@@ -52,107 +47,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->bootFlare();
-
         \Illuminate\Pagination\Paginator::useBootstrap();
 
         $this->bootCustomBladeDirectives();
         $this->bootCustomValidators();
         $this->configureMorphAliases();
         $this->bootObservers();
-    }
-
-    private function bootFlare(): void
-    {
-
-        // PHPStan (Larastan?) prevents us from skipping loading the service provider at all
-        // Not sure if bug or by design
-        if ($this->app->isProduction() && \LibreNMS\Config::get('reporting.error', false) == true) {
-            Config::set('flare.key', Config::get('librenms.flare_key'));
-        }
-
-        $this->app->register(\Facade\Ignition\IgnitionServiceProvider::class);
-
-        /**
-         * Filter reports based on conditions
-         */
-        Flare::filterReportsUsing(function (Report $report) {
-            // Only run in production
-            if (! $this->app->isProduction()) {
-                return false;
-            }
-
-            // Check if git installation
-            if (! Git::repoPresent()) {
-                return false;
-            }
-
-            // Repo url must be offical one
-            if (! Str::contains(Git::remoteUrl(), ['git@github.com:librenms/librenms.git', 'https://github.com/librenms/librenms.git'])) {
-                return false;
-            }
-
-            // Check if repo is modified
-            if (! Git::unchanged()) {
-                return false;
-            }
-
-            // Check if repo is modified
-            if (! Git::officalCommit()) {
-                return false;
-            }
-
-            return true;
-        });
-
-        Flare::determineVersionUsing(function () {
-            return \LibreNMS\Util\Version::VERSION;
-        });
-
-        Flare::registerMiddleware(function (Report $report, $next) {
-
-            // Filter some extra fields for privacy
-            // Move to header middleware when switching to spatie/laravel-ignition
-            try {
-                $report->setApplicationPath('');
-                $context = $report->allContext();
-
-                if (isset($context['request']['url'])) {
-                    $context['request']['url'] = str_replace($context['headers']['host'] ?? '', 'librenms', $context['request']['url']);
-                }
-
-                if (isset($context['session']['_previous']['url'])) {
-                    $context['session']['_previous']['url'] = str_replace($context['headers']['host'] ?? '', 'librenms', $context['session']['_previous']['url']);
-                }
-
-                $context['headers']['host'] = null;
-                $context['headers']['referer'] = null;
-
-                $report->userProvidedContext($context);
-            } catch (\Exception $e) {
-            }
-
-            // Add more LibreNMS related info
-            try {
-                $version = Version::get();
-
-                $report->group('LibreNMS', [
-                    'Git version' => $version->local(),
-                    'App version' => Version::VERSION,
-                ]);
-
-                $report->group('Tools', [
-                    'Database' => $version->databaseServer(),
-                    'Net-SNMP' => $version->netSnmp(),
-                    'Python' => $version->python(),
-                    'RRDtool' => $version->rrdtool(),
-
-                ]);
-            } catch (\Exception $e) {
-            }
-
-            return $next($report);
-        });
     }
 
     private function bootCustomBladeDirectives()
@@ -199,7 +99,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->alias(\LibreNMS\Interfaces\Geocoder::class, 'geocoder');
         $this->app->bind(\LibreNMS\Interfaces\Geocoder::class, function ($app) {
-            $engine = \LibreNMS\Config::get('geoloc.engine');
+            $engine = Config::get('geoloc.engine');
 
             switch ($engine) {
                 case 'mapquest':

--- a/app/Providers/ErrorReportingProvider.php
+++ b/app/Providers/ErrorReportingProvider.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * ErrorReportingProvider.php
+ *
+ * -Description-
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * @link       https://www.librenms.org
+ *
+ * @copyright  2022 Tony Murray
+ * @author     Tony Murray <murraytony@gmail.com>
+ */
+
+namespace App\Providers;
+
+use ErrorException;
+use Facade\FlareClient\Report;
+use Facade\Ignition\Facades\Flare;
+use Illuminate\Support\Str;
+use LibreNMS\Config;
+use LibreNMS\Util\Git;
+use LibreNMS\Util\Version;
+
+class ErrorReportingProvider extends \Facade\Ignition\IgnitionServiceProvider
+{
+    protected $errorReportingLevel = E_ALL & ~E_NOTICE;
+    private $laravelErrorHandler;
+
+    public function boot()
+    {
+        // don't report when:
+        Flare::filterExceptionsUsing(function (\Exception $e) {
+            if (! Config::get('reporting.error')) {
+                return false;
+            }
+
+            // Only run in production
+            if (! $this->app->isProduction()) {
+                return false;
+            }
+
+            // Check if git installation
+            if (! Git::repoPresent()) {
+                return false;
+            }
+
+            // Repo url must be offical one
+            if (! Str::contains(Git::remoteUrl(), ['git@github.com:librenms/librenms.git', 'https://github.com/librenms/librenms.git'])) {
+                return false;
+            }
+
+            // Check if repo is modified
+            if (! Git::unchanged()) {
+                return false;
+            }
+
+            // Check if repo is modified
+            if (! Git::officalCommit()) {
+                return false;
+            }
+
+            return true;
+        });
+
+        Flare::determineVersionUsing(function () {
+            return \LibreNMS\Util\Version::VERSION;
+        });
+
+        Flare::registerMiddleware(function (Report $report, $next) {
+
+            // Filter some extra fields for privacy
+            // Move to header middleware when switching to spatie/laravel-ignition
+            try {
+                $report->setApplicationPath('');
+                $context = $report->allContext();
+
+                if (isset($context['request']['url'])) {
+                    $context['request']['url'] = str_replace($context['headers']['host'] ?? '', 'librenms', $context['request']['url']);
+                }
+
+                if (isset($context['session']['_previous']['url'])) {
+                    $context['session']['_previous']['url'] = str_replace($context['headers']['host'] ?? '', 'librenms', $context['session']['_previous']['url']);
+                }
+
+                $context['headers']['host'] = null;
+                $context['headers']['referer'] = null;
+
+                $report->userProvidedContext($context);
+            } catch (\Exception $e) {
+            }
+
+            // Add more LibreNMS related info
+            try {
+                $version = Version::get();
+
+                $report->group('LibreNMS', [
+                    'Git version' => $version->local(),
+                    'App version' => Version::VERSION,
+                ]);
+
+                $report->group('Tools', [
+                    'Database' => $version->databaseServer(),
+                    'Net-SNMP' => $version->netSnmp(),
+                    'Python' => $version->python(),
+                    'RRDtool' => $version->rrdtool(),
+
+                ]);
+            } catch (\Exception $e) {
+            }
+
+            return $next($report);
+        });
+
+        // Override the Laravel error handler
+        $this->laravelErrorHandler = set_error_handler([$this, 'handleError']);
+
+        parent::boot();
+    }
+
+    /**
+     * Report PHP deprecations, or convert PHP errors to ErrorException instances.
+     *
+     * @param  int  $level
+     * @param  string  $message
+     * @param  string  $file
+     * @param  int  $line
+     * @param  array  $context
+     * @return void
+     *
+     * @throws \ErrorException
+     */
+    public function handleError($level, $message, $file = '', $line = 0, $context = [])
+    {
+        // report errors if they are allowed
+        if ($this->errorReportingLevel & $level) {
+            Flare::report(new ErrorException($message, 0, $level, $file, $line));
+        }
+
+        // call the laravel error handler, unless using a legacy entry point (init.php)
+        if (! defined('IGNORE_ERRORS')) {
+            call_user_func($this->laravelErrorHandler, $level, $message, $file, $line);
+        }
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -179,6 +179,7 @@ return [
          * LibreNMS Service Providers...
          */
         App\Providers\ConfigServiceProvider::class,
+        App\Providers\ErrorReportingProvider::class,
         App\Providers\AppServiceProvider::class,
         App\Providers\CliServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
@@ -246,6 +247,7 @@ return [
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View' => Illuminate\Support\Facades\View::class,
         'Debugbar' => Barryvdh\Debugbar\Facades\Debugbar::class,
+        'Flare' => Facade\Ignition\Facades\Flare::class,
 
         // LibreNMS
         'Permissions' => \App\Facades\Permissions::class,

--- a/config/flare.php
+++ b/config/flare.php
@@ -21,7 +21,7 @@ return [
     |
     */
 
-    'key' => null,
+    'key' => env('FLARE_KEY', 'quYFBTFNKHLBqFCoeo5yDVOQNbs6muV1'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/librenms.php
+++ b/config/librenms.php
@@ -53,14 +53,4 @@ return [
 
     'node_id' => env('NODE_ID'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Flare KEY
-    |--------------------------------------------------------------------------
-    |
-    | Key used to send errors to Flare
-    */
-
-    'flare_key' => env('FLARE_KEY', 'quYFBTFNKHLBqFCoeo5yDVOQNbs6muV1'),
-
 ];

--- a/includes/discovery/functions.inc.php
+++ b/includes/discovery/functions.inc.php
@@ -155,6 +155,7 @@ function discover_device(&$device, $force_module = false)
                 // isolate module exceptions so they don't disrupt the polling process
                 Log::error("%rError discovering $module module for {$device['hostname']}.%n $e", ['color' => true]);
                 Log::event("Error discovering $module module. Check log file for more details.", $device['device_id'], 'discovery', Alert::ERROR);
+                report($e);
             }
 
             $module_time = microtime(true) - $module_start;

--- a/includes/init.php
+++ b/includes/init.php
@@ -37,6 +37,7 @@ global $vars, $console_color;
 error_reporting(E_ERROR | E_PARSE | E_CORE_ERROR | E_COMPILE_ERROR);
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
+const IGNORE_ERRORS = true;
 
 $install_dir = realpath(__DIR__ . '/..');
 chdir($install_dir);
@@ -87,7 +88,6 @@ if (module_selected('web', $init_modules)) {
     Laravel::bootCli();
 }
 Debug::set($debug ?? false); // override laravel configured settings (hides legacy errors too)
-restore_error_handler(); // disable Laravel error handler
 
 if (! module_selected('nodb', $init_modules)) {
     if (! \LibreNMS\DB\Eloquent::isConnected()) {

--- a/includes/polling/functions.inc.php
+++ b/includes/polling/functions.inc.php
@@ -333,6 +333,7 @@ function poll_device($device, $force_module = false)
                     // isolate module exceptions so they don't disrupt the polling process
                     Log::error("%rError polling $module module for {$device['hostname']}.%n $e", ['color' => true]);
                     Log::event("Error polling $module module. Check log file for more details.", $device['device_id'], 'poller', Alert::ERROR);
+                    report($e);
                 }
 
                 $module_time = microtime(true) - $module_start;


### PR DESCRIPTION
 Move code to ErrorReportingProvider
 Enable reporting of error (and warning) messages.
 report module exceptions
set flare key in the normal place.  I confirmed early (before Flare::filterExceptionsUsing is called) and late (after Flare is booted) both behave correctly.