### PR TITLE
Replace snmp_getnext() with SnmpQuery::next() across all call sites

### DIFF
--- a/LibreNMS/OS/Netsure.php
+++ b/LibreNMS/OS/Netsure.php
@@ -28,11 +28,12 @@ namespace LibreNMS\OS;
 use App\Models\Device;
 use LibreNMS\Interfaces\Discovery\OSDiscovery;
 use LibreNMS\OS;
+use SnmpQuery;
 
 class Netsure extends OS implements OSDiscovery
 {
     public function discoverOS(Device $device): void
     {
-        $device->version = snmp_getnext($this->getDeviceArray(), 'vecFirmwareVersion', '-Oqv', 'VEC-MIBv5-9');
+        $device->version = SnmpQuery::next('VEC-MIBv5-9::vecFirmwareVersion')->value() ?: null;
     }
 }

--- a/LibreNMS/OS/Radlan.php
+++ b/LibreNMS/OS/Radlan.php
@@ -27,13 +27,14 @@
 namespace LibreNMS\OS;
 
 use App\Models\Device;
+use SnmpQuery;
 
 class Radlan extends \LibreNMS\OS
 {
     public function discoverOS(Device $device): void
     {
-        $device->hardware = snmp_getnext($this->getDeviceArray(), 'entPhysicalDescr.64', '-OsvQU', 'ENTITY-MIB');
+        $device->hardware = SnmpQuery::next('ENTITY-MIB::entPhysicalDescr.64')->value() ?: null;
         $device->version = snmp_get($this->getDeviceArray(), 'rndBrgVersion.0', '-OsvQU', 'RADLAN-MIB');
-        $device->serial = snmp_getnext($this->getDeviceArray(), 'entPhysicalSerialNum.64', '-OsvQU', 'ENTITY-MIB') ?: null;
+        $device->serial = SnmpQuery::next('ENTITY-MIB::entPhysicalSerialNum.64')->value() ?: null;
     }
 }

--- a/LibreNMS/OS/Topvision.php
+++ b/LibreNMS/OS/Topvision.php
@@ -30,15 +30,16 @@ use App\Models\Device;
 use LibreNMS\Interfaces\Data\DataStorageInterface;
 use LibreNMS\Interfaces\Polling\OSPolling;
 use LibreNMS\RRD\RrdDefinition;
+use SnmpQuery;
 
 class Topvision extends \LibreNMS\OS implements OSPolling
 {
     public function discoverOS(Device $device): void
     {
         parent::discoverOS($device); // yaml
-        $device->serial = snmp_getnext($this->getDeviceArray(), '.1.3.6.1.4.1.32285.11.1.1.2.1.1.1.16', '-OQv') ?: null;
+        $device->serial = SnmpQuery::numeric()->next('.1.3.6.1.4.1.32285.11.1.1.2.1.1.1.16')->value() ?: null;
         if (empty($device->hardware)) {
-            $device->hardware = snmp_getnext($this->getDeviceArray(), '.1.3.6.1.4.1.32285.11.1.1.2.1.1.1.18', '-OQv') ?: null;
+            $device->hardware = SnmpQuery::numeric()->next('.1.3.6.1.4.1.32285.11.1.1.2.1.1.1.18')->value() ?: null;
         }
     }
 

--- a/LibreNMS/OS/Vrp.php
+++ b/LibreNMS/OS/Vrp.php
@@ -250,7 +250,7 @@ class Vrp extends OS implements
         $device->version = isset($matches[1]) ? ($matches[1] . ($device->version ? " ($device->version)" : '')) : null; // version from yaml sysDescr
 
         if ($device->version) {
-            $patch = snmp_getnext($this->getDeviceArray(), 'HUAWEI-SYS-MAN-MIB::hwPatchVersion', '-OQv');
+            $patch = SnmpQuery::next('HUAWEI-SYS-MAN-MIB::hwPatchVersion')->value();
             if ($patch) {
                 $device->version .= " [$patch]";
             }

--- a/includes/discovery/sensors/current/liebert.inc.php
+++ b/includes/discovery/sensors/current/liebert.inc.php
@@ -31,7 +31,7 @@ $class = 'current';
 $poller_type = 'snmp';
 
 $psline_data = snmpwalk_cache_oid($device, 'lgpPduPsLineTable', [], 'LIEBERT-GP-PDU-MIB', 'liebert');
-$ec_input_rated = snmp_getnext($device, 'lgpPduPsEntryEcInputRated', '-OUqsev', 'LIEBERT-GP-PDU-MIB', 'liebert');
+$ec_input_rated = SnmpQuery::next('LIEBERT-GP-PDU-MIB::lgpPduPsEntryEcInputRated')->value();
 
 foreach (array_keys($psline_data) as $index) {
     $low_limit_p = $psline_data[$index]['lgpPduPsLineEntryEcThrshldUndrAlarm'] / 100;

--- a/phpstan-baseline-deprecated.neon
+++ b/phpstan-baseline-deprecated.neon
@@ -999,14 +999,6 @@ parameters:
 			count: 1
 			path: LibreNMS/OS/Netscaler.php
 
-		-
-			message: '''
-				#^Call to deprecated function snmp_getnext\(\)\:
-				Please use SnmpQuery instead$#
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: LibreNMS/OS/Netsure.php
 
 		-
 			message: '''
@@ -1125,14 +1117,6 @@ parameters:
 			count: 1
 			path: LibreNMS/OS/Radlan.php
 
-		-
-			message: '''
-				#^Call to deprecated function snmp_getnext\(\)\:
-				Please use SnmpQuery instead$#
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: LibreNMS/OS/Radlan.php
 
 		-
 			message: '''
@@ -1395,14 +1379,6 @@ parameters:
 			count: 1
 			path: LibreNMS/OS/Topvision.php
 
-		-
-			message: '''
-				#^Call to deprecated function snmp_getnext\(\)\:
-				Please use SnmpQuery instead$#
-			'''
-			identifier: function.deprecated
-			count: 2
-			path: LibreNMS/OS/Topvision.php
 
 		-
 			message: '''
@@ -1431,14 +1407,6 @@ parameters:
 			count: 1
 			path: LibreNMS/OS/Valere.php
 
-		-
-			message: '''
-				#^Call to deprecated function snmp_getnext\(\)\:
-				Please use SnmpQuery instead$#
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: LibreNMS/OS/Vrp.php
 
 		-
 			message: '''
@@ -2349,14 +2317,6 @@ parameters:
 			count: 1
 			path: includes/discovery/sensors/current/ict-pdu.inc.php
 
-		-
-			message: '''
-				#^Call to deprecated function snmp_getnext\(\)\:
-				Please use SnmpQuery instead$#
-			'''
-			identifier: function.deprecated
-			count: 1
-			path: includes/discovery/sensors/current/liebert.inc.php
 
 		-
 			message: '''


### PR DESCRIPTION
Migrates all 7 snmp_getnext() calls to use the SnmpQuery facade:
- Netsure: firmware version discovery
- Radlan: hardware and serial discovery
- Topvision: serial and hardware discovery
- Vrp: patch version discovery
- Liebert: PDU rated input current sensor discovery

Removes corresponding entries from phpstan-baseline-deprecated.neon.

https://claude.ai/code/session_01JabAN8U3pfkNaSiz8ExEyU