### PR TITLE
Add IfOperStatus enum for port ifOperStatus/ifAdminStatus fields

### DIFF
--- a/LibreNMS/Enum/IfOperStatus.php
+++ b/LibreNMS/Enum/IfOperStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace LibreNMS\Enum;
+
+enum IfOperStatus: string
+{
+    case Up = 'up';
+    case Down = 'down';
+    case Testing = 'testing';
+    case Unknown = 'unknown';
+    case Dormant = 'dormant';
+    case NotPresent = 'notPresent';
+    case LowerLayerDown = 'lowerLayerDown';
+}

--- a/LibreNMS/Snmptrap/Handlers/CieLinkDown.php
+++ b/LibreNMS/Snmptrap/Handlers/CieLinkDown.php
@@ -33,6 +33,7 @@
 namespace LibreNMS\Snmptrap\Handlers;
 
 use App\Models\Device;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
@@ -60,13 +61,13 @@ class CieLinkDown implements SnmptrapHandler
             return;
         }
 
-        $port->ifOperStatus = $trap->getOidData("IF-MIB::ifOperStatus.$ifIndex") ?: 'down';
+        $port->ifOperStatus = IfOperStatus::tryFrom($trap->getOidData("IF-MIB::ifOperStatus.$ifIndex")) ?? IfOperStatus::Down;
 
-        $trapAdminStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex");
+        $trapAdminStatus = IfOperStatus::tryFrom($trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex"));
         if ($trapAdminStatus) {
             $port->ifAdminStatus = $trapAdminStatus;
         }
-        $trap->log("Cisco cieLinkDown Trap: $port->ifDescr AdminStatus: $port->ifAdminStatus, OperStatus: $port->ifOperStatus", Severity::Error, 'interface', $port->port_id);
+        $trap->log("Cisco cieLinkDown Trap: $port->ifDescr AdminStatus: {$port->ifAdminStatus?->value}, OperStatus: {$port->ifOperStatus?->value}", Severity::Error, 'interface', $port->port_id);
 
         if ($port->isDirty('ifAdminStatus')) {
             $trap->log("Interface Disabled : $port->ifDescr (TRAP)", Severity::Notice, 'interface', $port->port_id);

--- a/LibreNMS/Snmptrap/Handlers/CieLinkUp.php
+++ b/LibreNMS/Snmptrap/Handlers/CieLinkUp.php
@@ -33,6 +33,7 @@
 namespace LibreNMS\Snmptrap\Handlers;
 
 use App\Models\Device;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
@@ -60,10 +61,10 @@ class CieLinkUp implements SnmptrapHandler
             return;
         }
 
-        $port->ifOperStatus = $trap->getOidData("IF-MIB::ifOperStatus.$ifIndex") ?: 'up';
-        $port->ifAdminStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex") ?: 'up'; // If we receive LinkUp trap, we can safely assume that the ifAdminStatus is also up.
+        $port->ifOperStatus = IfOperStatus::tryFrom($trap->getOidData("IF-MIB::ifOperStatus.$ifIndex")) ?? IfOperStatus::Up;
+        $port->ifAdminStatus = IfOperStatus::tryFrom($trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex")) ?? IfOperStatus::Up; // If we receive LinkUp trap, we can safely assume that the ifAdminStatus is also up.
 
-        $trap->log("Cisco cieLinkUp Trap: $port->ifDescr AdminStatus: $port->ifAdminStatus, OperStatus: $port->ifOperStatus", Severity::Ok, 'interface', $port->port_id);
+        $trap->log("Cisco cieLinkUp Trap: $port->ifDescr AdminStatus: {$port->ifAdminStatus?->value}, OperStatus: {$port->ifOperStatus?->value}", Severity::Ok, 'interface', $port->port_id);
 
         if ($port->isDirty('ifAdminStatus')) {
             $trap->log("Interface Enabled : $port->ifDescr (TRAP)", Severity::Notice, 'interface', $port->port_id);

--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortDown.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortDown.php
@@ -29,6 +29,7 @@
 namespace LibreNMS\Snmptrap\Handlers;
 
 use App\Models\Device;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
@@ -52,7 +53,7 @@ class CienaCesPortNotificationPortDown implements SnmptrapHandler
         $trap->log("Port down on Chassis: $chassis Shelf: $shelf Slot: $slot Port: $port", Severity::Error);
 
         $librePort = $device->ports()->where('ifIndex', $port)->first();
-        $librePort->ifOperStatus = 'down';
+        $librePort->ifOperStatus = IfOperStatus::Down;
         $librePort->save();
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortUp.php
+++ b/LibreNMS/Snmptrap/Handlers/CienaCesPortNotificationPortUp.php
@@ -29,6 +29,7 @@
 namespace LibreNMS\Snmptrap\Handlers;
 
 use App\Models\Device;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
@@ -52,7 +53,7 @@ class CienaCesPortNotificationPortUp implements SnmptrapHandler
         $trap->log("Port up on Chassis: $chassis Shelf: $shelf Slot: $slot Port: $port", Severity::Ok);
 
         $librePort = $device->ports()->where('ifIndex', $port)->first();
-        $librePort->ifOperStatus = 'up';
+        $librePort->ifOperStatus = IfOperStatus::Up;
         $librePort->save();
     }
 }

--- a/LibreNMS/Snmptrap/Handlers/LinkDown.php
+++ b/LibreNMS/Snmptrap/Handlers/LinkDown.php
@@ -27,6 +27,7 @@
 namespace LibreNMS\Snmptrap\Handlers;
 
 use App\Models\Device;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
@@ -54,13 +55,13 @@ class LinkDown implements SnmptrapHandler
             return;
         }
 
-        $port->ifOperStatus = 'down';
+        $port->ifOperStatus = IfOperStatus::Down;
 
-        $trapAdminStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex");
+        $trapAdminStatus = IfOperStatus::tryFrom($trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex"));
         if ($trapAdminStatus) {
             $port->ifAdminStatus = $trapAdminStatus;
         }
-        $trap->log("SNMP Trap: linkDown $port->ifAdminStatus/$port->ifOperStatus " . $port->ifDescr, Severity::Error, 'interface', $port->port_id);
+        $trap->log("SNMP Trap: linkDown {$port->ifAdminStatus?->value}/{$port->ifOperStatus?->value} " . $port->ifDescr, Severity::Error, 'interface', $port->port_id);
 
         if ($port->isDirty('ifAdminStatus')) {
             $trap->log("Interface Disabled : $port->ifDescr (TRAP)", Severity::Notice, 'interface', $port->port_id);

--- a/LibreNMS/Snmptrap/Handlers/LinkUp.php
+++ b/LibreNMS/Snmptrap/Handlers/LinkUp.php
@@ -27,6 +27,7 @@
 namespace LibreNMS\Snmptrap\Handlers;
 
 use App\Models\Device;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Interfaces\SnmptrapHandler;
 use LibreNMS\Snmptrap\Trap;
@@ -54,10 +55,10 @@ class LinkUp implements SnmptrapHandler
             return;
         }
 
-        $port->ifOperStatus = $trap->getOidData("IF-MIB::ifOperStatus.$ifIndex") ?: 'up';
-        $port->ifAdminStatus = $trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex") ?: 'up'; // If we receive LinkUp trap, we can safely assume that the ifAdminStatus is also up.
+        $port->ifOperStatus = IfOperStatus::tryFrom($trap->getOidData("IF-MIB::ifOperStatus.$ifIndex")) ?? IfOperStatus::Up;
+        $port->ifAdminStatus = IfOperStatus::tryFrom($trap->getOidData("IF-MIB::ifAdminStatus.$ifIndex")) ?? IfOperStatus::Up; // If we receive LinkUp trap, we can safely assume that the ifAdminStatus is also up.
 
-        $trap->log("SNMP Trap: linkUp $port->ifAdminStatus/$port->ifOperStatus " . $port->ifDescr, Severity::Ok, 'interface', $port->port_id);
+        $trap->log("SNMP Trap: linkUp {$port->ifAdminStatus?->value}/{$port->ifOperStatus?->value} " . $port->ifDescr, Severity::Ok, 'interface', $port->port_id);
 
         if ($port->isDirty('ifAdminStatus')) {
             $trap->log("Interface Enabled : $port->ifDescr (TRAP)", Severity::Notice, 'interface', $port->port_id);

--- a/LibreNMS/Util/Color.php
+++ b/LibreNMS/Util/Color.php
@@ -29,6 +29,7 @@ namespace LibreNMS\Util;
 use App\Models\BgpPeer;
 use App\Models\Device;
 use App\Models\Port;
+use LibreNMS\Enum\IfOperStatus;
 
 class Color
 {
@@ -122,12 +123,12 @@ class Color
         }
 
         // Shutdown ports
-        if ($port->ifAdminStatus === 'down') {
+        if ($port->ifAdminStatus == IfOperStatus::Down) {
             return '#808080';
         }
 
         // Down Ports
-        if ($port->ifOperStatus !== 'up') {
+        if ($port->ifOperStatus != IfOperStatus::Up) {
             return '#ff0000';
         }
 

--- a/LibreNMS/Util/Url.php
+++ b/LibreNMS/Util/Url.php
@@ -35,6 +35,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\URL as LaravelUrl;
 use Illuminate\Support\Str;
 use LibreNMS\Enum\DeviceStatus;
+use LibreNMS\Enum\IfOperStatus;
 use Request;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -521,11 +522,11 @@ class Url
      */
     public static function portLinkDisplayClass($port)
     {
-        if ($port->ifAdminStatus == 'down') {
+        if ($port->ifAdminStatus == IfOperStatus::Down) {
             return 'interface-admindown';
         }
 
-        if ($port->ifAdminStatus == 'up' && $port->ifOperStatus != 'up') {
+        if ($port->ifAdminStatus == IfOperStatus::Up && $port->ifOperStatus != IfOperStatus::Up) {
             return 'interface-updown';
         }
 

--- a/app/Http/Controllers/Maps/CustomMapDataController.php
+++ b/app/Http/Controllers/Maps/CustomMapDataController.php
@@ -36,6 +36,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Util\Number;
 
 class CustomMapDataController extends Controller
@@ -110,7 +111,7 @@ class CustomMapDataController extends Controller
                         $edges[$edgeid]['colour_to'] = 'darkred';
                         $edges[$edgeid]['colour_from'] = 'darkred';
                     }
-                } elseif ($edge->port->ifOperStatus != 'up') {
+                } elseif ($edge->port->ifOperStatus != IfOperStatus::Up) {
                     // If the port is not online, show the same as speed unknown
                     if ($map->legend_colours) {
                         $edges[$edgeid]['colour_to'] = $map->legend_colours['-1'];

--- a/app/Http/Controllers/Maps/MapDataController.php
+++ b/app/Http/Controllers/Maps/MapDataController.php
@@ -39,6 +39,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
+use LibreNMS\Enum\IfOperStatus;
 
 class MapDataController extends Controller
 {
@@ -678,7 +679,7 @@ class MapDataController extends Controller
                                 'color' => LibrenmsConfig::get('network_map_legend.dn.edge'),
                             ],
                         ];
-                    } elseif ($port->ifOperStatus == 'down' || $remote_port->ifOperStatus == 'down') {
+                    } elseif ($port->ifOperStatus == IfOperStatus::Down || $remote_port->ifOperStatus == IfOperStatus::Down) {
                         // If either port is offline, mark the link as being down
                         $link_style = [
                             'dashes' => [8, 12],

--- a/app/Http/Controllers/Table/EditPortsController.php
+++ b/app/Http/Controllers/Table/EditPortsController.php
@@ -26,6 +26,8 @@
 
 namespace App\Http\Controllers\Table;
 
+use LibreNMS\Enum\IfOperStatus;
+
 class EditPortsController extends TableController
 {
     public function rules()
@@ -59,7 +61,7 @@ class EditPortsController extends TableController
      */
     public function formatItem($port)
     {
-        $is_port_bad = $port->ifAdminStatus != 'down' && $port->ifOperStatus != 'up';
+        $is_port_bad = $port->ifAdminStatus != IfOperStatus::Down && $port->ifOperStatus != IfOperStatus::Up;
         $do_we_care = ($port->ignore || $port->disabled) ? false : $is_port_bad;
         $out_of_sync = $do_we_care ? "class='red'" : '';
         $tune = $port->device->getAttrib('ifName_tune:' . $port->ifName) == 'true' ? 'checked' : '';
@@ -74,8 +76,8 @@ class EditPortsController extends TableController
         return [
             'ifIndex' => $port->ifIndex,
             'ifName' => htmlentities($port->getLabel()),
-            'ifAdminStatus' => htmlentities((string) $port->ifAdminStatus),
-            'ifOperStatus' => '<span id="operstatus_' . $port->port_id . '" ' . $out_of_sync . '>' . htmlentities((string) $port->ifOperStatus) . '</span>',
+            'ifAdminStatus' => htmlentities($port->ifAdminStatus->value ?? ''),
+            'ifOperStatus' => '<span id="operstatus_' . $port->port_id . '" ' . $out_of_sync . '>' . htmlentities($port->ifOperStatus->value ?? '') . '</span>',
             'disabled' => '<input type="checkbox" class="disable-check" data-size="small" name="disabled_' . $port->port_id . '"' . ($port->disabled ? 'checked' : '') . '>
                                <input type="hidden" name="olddis_' . $port->port_id . '" value="' . ($port->disabled ? 1 : 0) . '"">',
             'ignore' => '<input type="checkbox" class="ignore-check" data-size="small" name="ignore_' . $port->port_id . '"' . ($port->ignore ? 'checked' : '') . '>

--- a/app/Http/Controllers/Table/PortsController.php
+++ b/app/Http/Controllers/Table/PortsController.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\DB;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Rewrite;
 use LibreNMS\Util\Url;
@@ -134,8 +135,8 @@ class PortsController extends TableController
      */
     public function formatItem($port)
     {
-        $status = $port->ifOperStatus == 'down'
-            ? ($port->ifAdminStatus == 'up' ? 'label-danger' : 'label-warning')
+        $status = $port->ifOperStatus == IfOperStatus::Down
+            ? ($port->ifAdminStatus == IfOperStatus::Up ? 'label-danger' : 'label-warning')
             : 'label-success';
 
         return [
@@ -199,8 +200,8 @@ class PortsController extends TableController
      */
     protected function formatExportRow($port)
     {
-        $status = $port->ifOperStatus;
-        $adminStatus = $port->ifAdminStatus;
+        $status = $port->ifOperStatus?->value;
+        $adminStatus = $port->ifAdminStatus?->value;
         $speed = Number::formatSi($port->ifSpeed);
 
         return [

--- a/app/Http/Controllers/Widgets/GlobeController.php
+++ b/app/Http/Controllers/Widgets/GlobeController.php
@@ -31,6 +31,7 @@ use App\Models\Location;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\View\View;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Util\Number;
 
 class GlobeController extends WidgetController
@@ -76,7 +77,7 @@ class GlobeController extends WidgetController
                 $down_items = $devices_down->map(fn ($device) => $device->displayName() . ' DOWN');
             } elseif ($data['markers'] == 'ports') {
                 foreach ($location->devices as $device) {
-                    [$ports_down, $ports_up] = $device->ports->partition(fn ($port) => $port->ifOperStatus != 'up' && $port->ifAdminStatus == 'up');
+                    [$ports_down, $ports_up] = $device->ports->partition(fn ($port) => $port->ifOperStatus != IfOperStatus::Up && $port->ifAdminStatus == IfOperStatus::Up);
                     $count += $device->ports->count();
                     $up += $ports_up->count();
                     $down_items = $ports_down->map(fn ($port) => $device->displayName() . '/' . $port->getShortLabel() . ' DOWN');

--- a/app/Models/Port.php
+++ b/app/Models/Port.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Util\Number;
 use LibreNMS\Util\Rewrite;
 
@@ -22,6 +23,19 @@ class Port extends DeviceRelatedModel
     public $timestamps = false;
     protected $primaryKey = 'port_id';
     protected $guarded = [];
+
+    /**
+     * @return array{ifOperStatus: 'LibreNMS\Enum\IfOperStatus', ifOperStatus_prev: 'LibreNMS\Enum\IfOperStatus', ifAdminStatus: 'LibreNMS\Enum\IfOperStatus', ifAdminStatus_prev: 'LibreNMS\Enum\IfOperStatus'}
+     */
+    protected function casts(): array
+    {
+        return [
+            'ifOperStatus' => IfOperStatus::class,
+            'ifOperStatus_prev' => IfOperStatus::class,
+            'ifAdminStatus' => IfOperStatus::class,
+            'ifAdminStatus_prev' => IfOperStatus::class,
+        ];
+    }
 
     /**
      * Initialize this class
@@ -200,7 +214,7 @@ class Port extends DeviceRelatedModel
             [$this->qualifyColumn('deleted'), '=', 0],
             [$this->qualifyColumn('ignore'), '=', 0],
             [$this->qualifyColumn('disabled'), '=', 0],
-            [$this->qualifyColumn('ifOperStatus'), '=', 'up'],
+            [$this->qualifyColumn('ifOperStatus'), '=', IfOperStatus::Up],
         ]);
     }
 
@@ -214,8 +228,8 @@ class Port extends DeviceRelatedModel
             [$this->qualifyColumn('deleted'), '=', 0],
             [$this->qualifyColumn('ignore'), '=', 0],
             [$this->qualifyColumn('disabled'), '=', 0],
-            [$this->qualifyColumn('ifOperStatus'), '!=', 'up'],
-            [$this->qualifyColumn('ifAdminStatus'), '=', 'up'],
+            [$this->qualifyColumn('ifOperStatus'), '!=', IfOperStatus::Up],
+            [$this->qualifyColumn('ifAdminStatus'), '=', IfOperStatus::Up],
         ]);
     }
 
@@ -229,7 +243,7 @@ class Port extends DeviceRelatedModel
             [$this->qualifyColumn('deleted'), '=', 0],
             [$this->qualifyColumn('ignore'), '=', 0],
             [$this->qualifyColumn('disabled'), '=', 0],
-            [$this->qualifyColumn('ifAdminStatus'), '=', 'down'],
+            [$this->qualifyColumn('ifAdminStatus'), '=', IfOperStatus::Down],
         ]);
     }
 

--- a/app/View/Components/PortLink.php
+++ b/app/View/Components/PortLink.php
@@ -5,6 +5,7 @@ namespace App\View\Components;
 use App\Models\Port;
 use Illuminate\Support\Arr;
 use Illuminate\View\Component;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Util\Rewrite;
 use LibreNMS\Util\Url;
 
@@ -71,11 +72,11 @@ class PortLink extends Component
 
     private function status(): string
     {
-        if ($this->port->ifAdminStatus == 'down') {
+        if ($this->port->ifAdminStatus == IfOperStatus::Down) {
             return 'disabled';
         }
 
-        return $this->port->ifAdminStatus == 'up' && $this->port->ifOperStatus != 'up'
+        return $this->port->ifAdminStatus == IfOperStatus::Up && $this->port->ifOperStatus != IfOperStatus::Up
             ? 'down'
             : 'up';
     }

--- a/includes/discovery/sensors/current/comware.inc.php
+++ b/includes/discovery/sensors/current/comware.inc.php
@@ -12,6 +12,8 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
 */
+use LibreNMS\Enum\IfOperStatus;
+
 echo 'Comware ';
 
 $multiplier = 1;
@@ -21,7 +23,7 @@ $hh3cTransceiverInfoTable = SnmpQuery::cache()->enumStrings()->walk('HH3C-TRANSC
 foreach ($hh3cTransceiverInfoTable as $index => $entry) {
     if (is_numeric($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverBiasCurrent']) && $entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverBiasCurrent'] != 2147483647 && isset($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverDiagnostic'])) {
         $port = PortCache::getByIfIndex($index, $device['device_id']);
-        if ($port?->ifAdminStatus != 'up') {
+        if ($port?->ifAdminStatus != IfOperStatus::Up) {
             continue;
         }
 

--- a/includes/discovery/sensors/dbm/comware.inc.php
+++ b/includes/discovery/sensors/dbm/comware.inc.php
@@ -12,6 +12,8 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
 */
+use LibreNMS\Enum\IfOperStatus;
+
 echo 'Comware ';
 
 $multiplier = 1;
@@ -20,7 +22,7 @@ $hh3cTransceiverInfoTable = SnmpQuery::cache()->enumStrings()->walk('HH3C-TRANSC
 foreach ($hh3cTransceiverInfoTable as $index => $entry) {
     if (is_numeric($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverCurRXPower']) && $entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverCurRXPower'] != 2147483647 && isset($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverDiagnostic'])) {
         $port = PortCache::getByIfIndex($index, $device['device_id']);
-        if ($port?->ifAdminStatus != 'up') {
+        if ($port?->ifAdminStatus != IfOperStatus::Up) {
             continue;
         }
 
@@ -46,7 +48,7 @@ foreach ($hh3cTransceiverInfoTable as $index => $entry) {
         $entPhysicalIndex = $index;
         $entPhysicalIndex_measured = 'ports';
         $port = PortCache::getByIfIndex($index, $device['device_id']);
-        if ($port?->ifAdminStatus == 'up') {
+        if ($port?->ifAdminStatus == IfOperStatus::Up) {
             $descr = $port->getShortLabel() . ' Transmit Power';
             discover_sensor(null, 'dbm', $device, $oid, 'tx-' . $index, 'comware', $descr, $divisor, $multiplier, $limit_low, $warn_limit_low, $warn_limit, $limit, $current, 'snmp', $entPhysicalIndex, $entPhysicalIndex_measured, group: 'transceiver');
         }

--- a/includes/discovery/sensors/state/ciscosb.inc.php
+++ b/includes/discovery/sensors/state/ciscosb.inc.php
@@ -22,6 +22,7 @@
  */
 
 use Illuminate\Support\Str;
+use LibreNMS\Enum\IfOperStatus;
 
 $temp = SnmpQuery::hideMib()->walk('CISCOSB-rlInterfaces::swIfOperSuspendedStatus')->table(0);
 
@@ -40,7 +41,7 @@ if (! empty($temp)) {
         $port = PortCache::getByIfIndex(preg_replace('/^\d+\./', '', (string) $index), $device['device_id']);
         $descr = trim($port?->ifDescr . ' Suspended Status');
 
-        if (Str::contains($descr, ['ethernet', 'Ethernet']) && $port?->ifOperStatus !== 'notPresent') {
+        if (Str::contains($descr, ['ethernet', 'Ethernet']) && $port?->ifOperStatus != IfOperStatus::NotPresent) {
             //Discover Sensors
             discover_sensor(null, 'state', $device, $cur_oid . $index, $index, $state_name, $descr, 1, 1, null, null, null, null, $value, 'snmp', $index);
         }

--- a/includes/discovery/sensors/temperature/comware.inc.php
+++ b/includes/discovery/sensors/temperature/comware.inc.php
@@ -12,6 +12,8 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
 */
+use LibreNMS\Enum\IfOperStatus;
+
 echo 'Comware ';
 
 $entphydata = DeviceCache::getPrimary()->entityPhysical()
@@ -62,7 +64,7 @@ $hh3cTransceiverInfoTable = SnmpQuery::cache()->enumStrings()->walk('HH3C-TRANSC
 foreach ($hh3cTransceiverInfoTable as $index => $entry) {
     if (is_numeric($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverTemperature']) && $entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverTemperature'] != 2147483647 && isset($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverDiagnostic'])) {
         $port = PortCache::getByIfIndex($index, $device['device_id']);
-        if ($port?->ifAdminStatus != 'up') {
+        if ($port?->ifAdminStatus != IfOperStatus::Up) {
             continue;
         }
 

--- a/includes/discovery/sensors/voltage/comware.inc.php
+++ b/includes/discovery/sensors/voltage/comware.inc.php
@@ -12,6 +12,8 @@
  *
  * @author     Peca Nesovanovic <peca.nesovanovic@sattrakt.com>
 */
+use LibreNMS\Enum\IfOperStatus;
+
 echo 'Comware ';
 
 $multiplier = 1;
@@ -21,7 +23,7 @@ $hh3cTransceiverInfoTable = SnmpQuery::cache()->enumStrings()->walk('HH3C-TRANSC
 foreach ($hh3cTransceiverInfoTable as $index => $entry) {
     if (is_numeric($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverVoltage']) && $entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverVoltage'] != 2147483647 && isset($entry['HH3C-TRANSCEIVER-INFO-MIB::hh3cTransceiverDiagnostic'])) {
         $port = PortCache::getByIfIndex($index, $device['device_id']);
-        if ($port?->ifAdminStatus != 'up') {
+        if ($port?->ifAdminStatus != IfOperStatus::Up) {
             continue;
         }
 

--- a/includes/html/pages/device/port.inc.php
+++ b/includes/html/pages/device/port.inc.php
@@ -10,6 +10,7 @@ use App\Models\PortVlan;
 use App\Models\Sensor;
 use App\Plugins\Hooks\PortTabHook;
 use Illuminate\Support\Facades\Gate;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Util\Rewrite;
 use LibreNMS\Util\Url;
 
@@ -31,15 +32,15 @@ if ($port->ifPhysAddress) {
 }
 
 $color = 'black';
-if ($port->ifAdminStatus == 'down') {
+if ($port->ifAdminStatus == IfOperStatus::Down) {
     $status = "<span class='grey'>Disabled</span>";
 }
 
-if ($port->ifAdminStatus == 'up' && $port->ifOperStatus != 'up') {
+if ($port->ifAdminStatus == IfOperStatus::Up && $port->ifOperStatus != IfOperStatus::Up) {
     $status = "<span class='red'>Enabled / Disconnected</span>";
 }
 
-if ($port->ifAdminStatus == 'up' && $port->ifOperStatus == 'up') {
+if ($port->ifAdminStatus == IfOperStatus::Up && $port->ifOperStatus == IfOperStatus::Up) {
     $status = "<span class='green'>Enabled / Connected</span>";
 }
 

--- a/tests/Feature/SnmpTraps/CieLinkDownTest.php
+++ b/tests/Feature/SnmpTraps/CieLinkDownTest.php
@@ -27,6 +27,7 @@ namespace LibreNMS\Tests\Feature\SnmpTraps;
 use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Tests\Traits\RequiresDatabase;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -66,7 +67,7 @@ IF-MIB::ifType.$port->ifIndex ethernetCsmacd",
         );
 
         $port = $port->fresh();
-        $this->assertEquals('up', $port->ifAdminStatus);
-        $this->assertEquals('down', $port->ifOperStatus);
+        $this->assertEquals(IfOperStatus::Up, $port->ifAdminStatus);
+        $this->assertEquals(IfOperStatus::Down, $port->ifOperStatus);
     }
 }

--- a/tests/Feature/SnmpTraps/CieLinkUpTest.php
+++ b/tests/Feature/SnmpTraps/CieLinkUpTest.php
@@ -27,6 +27,7 @@ namespace LibreNMS\Tests\Feature\SnmpTraps;
 use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Tests\Traits\RequiresDatabase;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -68,7 +69,7 @@ IF-MIB::ifType.$port->ifIndex ethernetCsmacd",
         );
 
         $port = $port->fresh();
-        $this->assertEquals('up', $port->ifAdminStatus);
-        $this->assertEquals('up', $port->ifOperStatus);
+        $this->assertEquals(IfOperStatus::Up, $port->ifAdminStatus);
+        $this->assertEquals(IfOperStatus::Up, $port->ifOperStatus);
     }
 }

--- a/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
+++ b/tests/Feature/SnmpTraps/CienaCesPortNotificationTrapTest.php
@@ -31,6 +31,7 @@ namespace LibreNMS\Tests\Feature\SnmpTraps;
 use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Tests\Traits\RequiresDatabase;
 
@@ -66,7 +67,7 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         );
 
         $port = $port->fresh(); // refresh from database
-        $this->assertEquals($port->ifOperStatus, 'down');
+        $this->assertEquals(IfOperStatus::Down, $port->ifOperStatus);
     }
 
     public function testCienaCesPortUpNotification(): void
@@ -97,6 +98,6 @@ CIENA-CES-PORT-MIB::cienaCesLogicalPortConfigPortDesc $port->ifDescr",
         );
 
         $port = $port->fresh(); // refresh from database
-        $this->assertEquals($port->ifOperStatus, 'up');
+        $this->assertEquals(IfOperStatus::Up, $port->ifOperStatus);
     }
 }

--- a/tests/Feature/SnmpTraps/PortsTrapTest.php
+++ b/tests/Feature/SnmpTraps/PortsTrapTest.php
@@ -29,6 +29,7 @@ namespace LibreNMS\Tests\Feature\SnmpTraps;
 use App\Models\Device;
 use App\Models\Port;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use LibreNMS\Enum\IfOperStatus;
 use LibreNMS\Enum\Severity;
 use LibreNMS\Tests\Traits\RequiresDatabase;
 
@@ -69,8 +70,8 @@ OLD-CISCO-INTERFACES-MIB::locIfReason.$port->ifIndex \"down\"\n",
         );
 
         $port = $port->fresh(); // refresh from database
-        $this->assertEquals($port->ifAdminStatus, 'down');
-        $this->assertEquals($port->ifOperStatus, 'down');
+        $this->assertEquals(IfOperStatus::Down, $port->ifAdminStatus);
+        $this->assertEquals(IfOperStatus::Down, $port->ifOperStatus);
     }
 
     public function testLinkUp(): void
@@ -105,7 +106,7 @@ OLD-CISCO-INTERFACES-MIB::locIfReason.$port->ifIndex \"up\"\n",
         );
 
         $port = $port->fresh(); // refresh from database
-        $this->assertEquals($port->ifAdminStatus, 'up');
-        $this->assertEquals($port->ifOperStatus, 'up');
+        $this->assertEquals(IfOperStatus::Up, $port->ifAdminStatus);
+        $this->assertEquals(IfOperStatus::Up, $port->ifOperStatus);
     }
 }


### PR DESCRIPTION
Replace bare string comparisons ('up', 'down', 'notPresent', etc.)
with a proper PHP string-backed enum for ifOperStatus and
ifAdminStatus on the Port model. These fields represent IF-MIB
standard values (RFC 2863) and are used across 84 files.

Changes:
- Create LibreNMS\Enum\IfOperStatus with all 7 IF-MIB values
- Add enum casts to Port model for ifOperStatus, ifAdminStatus,
  and their _prev variants
- Update all model-based comparisons to use enum constants
- Update trap handlers to use enum constants and fix string
  interpolation for enum properties
- Update sensor discovery files using Port model access
- Update test assertions to compare against enum values

https://claude.ai/code/session_01As6Le9Go4zKNaiTzEeB2jZ